### PR TITLE
using jiocloud repo instead of upstream for patches purpose

### DIFF
--- a/noauth.xml
+++ b/noauth.xml
@@ -15,7 +15,7 @@
 <project name="contrail-packages" remote="JioCloud" path="tools/packages">
   <copyfile src="packages.make" dest="packages.make"/>
 </project>
-<project name="contrail-nova-vif-driver" remote="github" path="openstack/nova_contrail_vif"/>
+<project name="contrail-nova-vif-driver" remote="JioCloud" path="openstack/nova_contrail_vif"/>
 <project name="contrail-neutron-plugin" remote="github" path="openstack/neutron_plugin"/>
 <project name="contrail-web-controller" remote="github"/>
 <project name="contrail-web-core" remote="github"/>


### PR DESCRIPTION
required for using https://github.com/JioCloud/contrail-nova-vif-driver/pull/1